### PR TITLE
Add logout functionality

### DIFF
--- a/src/components/Menu/index.js
+++ b/src/components/Menu/index.js
@@ -5,9 +5,15 @@ import Divider from 'material-ui/Divider'
 import Drawer from 'material-ui/Drawer'
 import FontIcon from 'material-ui/FontIcon'
 import MenuItem from 'material-ui/MenuItem'
+import withNavigation from '@hocs/withNavigation'
 
 /* eslint-disable arrow-body-style */
 class Menu extends React.Component {
+  static propTypes = {
+    logout: PropTypes.func.isRequired,
+    goTo: PropTypes.func.isRequired,
+  }
+
   state = {
     open: false,
   };
@@ -17,6 +23,16 @@ class Menu extends React.Component {
   };
 
   render() {
+    const {
+      logout,
+      goTo,
+    } = this.props
+
+    const redirect = (page) => {
+      this.handleChange()
+      goTo(page)
+    }
+
     return (
       <div>
         <AppBar
@@ -40,74 +56,74 @@ class Menu extends React.Component {
           >
             Hedwig
           </MenuItem>
-          <a href="/access" style={{ textDecoration: 'none' }}>
+          <div onTouchTap={() => redirect('/access')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-lock" />}
             >
               Acesso
             </MenuItem>
-          </a>
-          <a href="/aquarium" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={() => redirect('/aquarium')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-tint" />}
             >
               Aquário
             </MenuItem>
-          </a>
-          <a href="/hallway" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={() => redirect('/hallway')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-square" />}
             >
               Corredor
             </MenuItem>
-          </a>
-          <a href="/kitchen" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={() => redirect('/kitchen')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-cutlery" />}
             >
               Cozinha
             </MenuItem>
-          </a>
-          <a href="/laundry" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={() => redirect('/laundry')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-shirtsinbulk" />}
             >
               Lavanderia
             </MenuItem>
-          </a>
-          <a href="/livingroom" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={() => redirect('/livingroom')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-television" />}
             >
               Sala
             </MenuItem>
-          </a>
-          <a href="/#" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={() => redirect('#')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-plus-circle" />}
             >
               Adicionar módulo...
             </MenuItem>
-          </a>
+          </div>
           <Divider />
-          <a href="/#" style={{ textDecoration: 'none' }}>
+          <div onTouchTap={() => redirect('#')}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-cog" />}
             >
               Configurações
             </MenuItem>
-          </a>
-          <a href="/#" style={{ textDecoration: 'none' }}>
+          </div>
+          <div onTouchTap={logout}>
             <MenuItem
               leftIcon={<FontIcon className="fa fa-sign-out" />}
             >
               Sair
             </MenuItem>
-          </a>
+          </div>
         </Drawer>
       </div>
     )
   }
 }
 
-export default Menu
+export default withNavigation(Menu)

--- a/src/containers/Menu/index.js
+++ b/src/containers/Menu/index.js
@@ -1,0 +1,16 @@
+import { connect } from 'react-redux'
+import { compose } from 'redux'
+import { push } from 'react-router-redux';
+import Menu from '@components/Menu'
+import * as authActions from '@modules/auth/actions/authActions.js'
+
+const mapDispatchToProps = dispatch => ({
+  logout() {
+    dispatch(authActions.logout())
+    dispatch(push('/'))
+  },
+})
+
+export default compose(
+  connect(null, mapDispatchToProps),
+)(Menu)

--- a/src/hocs/requireAuthentication.js
+++ b/src/hocs/requireAuthentication.js
@@ -1,9 +1,15 @@
 import React, { PropTypes } from 'react'
 import { connect } from 'react-redux'
 import { push } from 'react-router-redux'
+import Menu from '@containers/Menu'
 
 export const requireAuthentication = (doRequire, Component) => {
   class AuthenticatedComponent extends React.Component {
+    static propTypes = {
+      isAuthenticated: PropTypes.func.isRequired,
+      dispatch: PropTypes.func.isRequired,
+    }
+
     componentWillMount() {
       this.checkAuth()
     }
@@ -14,22 +20,22 @@ export const requireAuthentication = (doRequire, Component) => {
 
     checkAuth() {
       if (!this.props.isAuthenticated && doRequire) {
-        this.props.dispatch(push(`/`))
-      }
-      else if (this.props.isAuthenticated && !doRequire) {
-        this.props.dispatch(push(`/access`))
+        this.props.dispatch(push('/'))
+      } else if (this.props.isAuthenticated && !doRequire) {
+        this.props.dispatch(push('/access'))
       }
     }
     render() {
       return (
         <div style={{ height: '100%' }}>
+          {this.props.isAuthenticated && (<Menu />)}
           <Component {...this.props} />
         </div>
       )
     }
   }
   const mapStateToProps = state => ({
-    isAuthenticated: state.auth.get('isAuthenticated')
+    isAuthenticated: state.auth.get('isAuthenticated'),
   })
   return connect(mapStateToProps)(AuthenticatedComponent);
 }

--- a/src/modules/auth/actions/authActions.js
+++ b/src/modules/auth/actions/authActions.js
@@ -76,13 +76,19 @@ const loginFailure = error => ({
   },
 })
 
+const normalizeToken = (token) => {
+  const splittedToken = token.split(' ')
+  return splittedToken[splittedToken.length - 1]
+}
+
 export const login = creds => ((dispatch) => {
   dispatch(requestLogin(creds))
 
   return unauthenticatedPost('user/authenticate', creds)
     .then((response) => {
-      localStorage.setItem('token', response.data.token)
+      localStorage.setItem('token', normalizeToken(response.data.token))
       dispatch(loginSuccess(response))
+      return true
     })
     .catch((error) => {
       const data = error.data
@@ -90,7 +96,8 @@ export const login = creds => ((dispatch) => {
       if (data) {
         message = data.message
       }
-      dispatch(loginFailure(message ? message : 'Default message'))
+      dispatch(loginFailure(message ? message : 'Erro no login'))
+      return false
     })
 })
 
@@ -100,7 +107,7 @@ const receiveLogout = () => ({
   isAuthenticated: false,
 })
 
-export const logoutUser = () => ((dispatch) => {
+export const logout = () => ((dispatch) => {
   localStorage.removeItem('token')
   dispatch(receiveLogout())
 })

--- a/src/routes/AccessModulePage/index.js
+++ b/src/routes/AccessModulePage/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import Menu from '@components/Menu'
 import StatusBox from '@routes/AccessModulePage/containers/StatusBox'
 import RelayControl from '@routes/AccessModulePage/containers/RelayControl'
 import Keyboard from '@routes/AccessModulePage/containers/Keyboard'
@@ -36,7 +35,6 @@ class AccessModulePage extends Component {
   render() {
     return (
       <Wrapper>
-        <Menu />
         <Content lessThanSmall={this.props.lessThanSmall}>
           <StatusBox />
           <br />

--- a/src/routes/AquariumModulePage/index.js
+++ b/src/routes/AquariumModulePage/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import Menu from '@components/Menu'
 import StatusBox from '@routes/AquariumModulePage/containers/StatusBox'
 import RelayControl from '@routes/AquariumModulePage/containers/RelayControl'
 
@@ -22,7 +21,6 @@ class AquariumModulePage extends Component {
   render() {
     return (
       <Wrapper>
-        <Menu />
         <Content lessThanSmall={this.props.lessThanSmall}>
           <StatusBox />
           <br />

--- a/src/routes/HallwayModulePage/index.js
+++ b/src/routes/HallwayModulePage/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import Menu from '@components/Menu'
 import StatusBox from '@routes/HallwayModulePage/containers/StatusBox'
 import RelayControl from '@routes/HallwayModulePage/containers/RelayControl'
 
@@ -22,7 +21,6 @@ class HallwayModulePage extends Component {
   render() {
     return (
       <Wrapper>
-        <Menu />
         <Content lessThanSmall={this.props.lessThanSmall}>
           <StatusBox />
           <br />

--- a/src/routes/KitchenModulePage/index.js
+++ b/src/routes/KitchenModulePage/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import Menu from '@components/Menu'
 import StatusBox from '@routes/KitchenModulePage/containers/StatusBox'
 import RelayControl from '@routes/KitchenModulePage/containers/RelayControl'
 
@@ -22,7 +21,6 @@ class KitchenModulePage extends Component {
   render() {
     return (
       <Wrapper>
-        <Menu />
         <Content lessThanSmall={this.props.lessThanSmall}>
           <StatusBox />
           <br />

--- a/src/routes/LandingPage/containers/Login.js
+++ b/src/routes/LandingPage/containers/Login.js
@@ -1,6 +1,7 @@
 import { connect } from 'react-redux'
 import { compose } from 'redux'
 import { reduxForm } from 'redux-form'
+import { push } from 'react-router-redux';
 import validator from '@helpers/validator'
 import schema from '@schemas/login'
 import LoginForm from '@routes/LandingPage/components/LoginForm'
@@ -10,7 +11,12 @@ const validate = values => validator(values, schema)
 
 const mapDispatchToProps = dispatch => ({
   login(creds) {
-    dispatch(authActions.login(creds))
+    dispatch(authActions.login(creds)).then(
+      (success) => {
+        if (success) {
+          dispatch(push('/access'))
+        }
+      })
   },
   clearError() {
     dispatch(authActions.clearAuthErrors())

--- a/src/routes/LaundryModulePage/index.js
+++ b/src/routes/LaundryModulePage/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import Menu from '@components/Menu'
 import StatusBox from '@routes/LaundryModulePage/containers/StatusBox'
 import RelayControl from '@routes/LaundryModulePage/containers/RelayControl'
 
@@ -22,7 +21,6 @@ class LaundryModulePage extends Component {
   render() {
     return (
       <Wrapper>
-        <Menu />
         <Content lessThanSmall={this.props.lessThanSmall}>
           <StatusBox />
           <br />

--- a/src/routes/LivingRoomModulePage/index.js
+++ b/src/routes/LivingRoomModulePage/index.js
@@ -1,7 +1,6 @@
 import React, { Component, PropTypes } from 'react'
 import { connect } from 'react-redux'
 import styled from 'styled-components'
-import Menu from '@components/Menu'
 import StatusBox from '@routes/LivingRoomModulePage/containers/StatusBox'
 import RelayControl from '@routes/LivingRoomModulePage/containers/RelayControl'
 
@@ -22,7 +21,6 @@ class LivingRoomModulePage extends Component {
   render() {
     return (
       <Wrapper>
-        <Menu />
         <Content lessThanSmall={this.props.lessThanSmall}>
           <StatusBox />
           <br />


### PR DESCRIPTION
Resolves #38 

- Changes menu redirect: make it change page inside redux router, instead of using `<a href=''>`
- Puts menu in all authenticated pages (in a DRY manner)
- Adds functionality to logout button
- Removes 'JWT ' prefix from token when there is such prefix on token received on authentication
- Redirects to access page after login