### PR TITLE
Fix device added snackbar

### DIFF
--- a/src/components/DeviceAddedSnackbar.js
+++ b/src/components/DeviceAddedSnackbar.js
@@ -18,7 +18,7 @@ class DeviceAddedSnackbar extends React.Component {
   componentWillReceiveProps(nextProps) {
     const { deviceCount } = this.props
 
-    if (nextProps.deviceCount > deviceCount) {
+    if (nextProps.deviceCount > deviceCount && deviceCount > 0) {
       this.setState({ open: true })
     }
   }


### PR DESCRIPTION
Don't show snackbar if it's the first load of the page.